### PR TITLE
fix usage of `open`

### DIFF
--- a/server.c
+++ b/server.c
@@ -96,7 +96,7 @@ int main( int argc, char *argv[] )
     struct data input; //Struct for input
 
     //Opening the second FIFO    
-    if( (cd = open( CF, O_WRONLY|| O_NONBLOCK )) < 0 )
+    if( (cd = open( CF, O_WRONLY | O_NONBLOCK )) < 0 )
     { 
         perror( CF );
         exit( 1 ); 


### PR DESCRIPTION
O_WRONLY || O_NONBLOCK always evaluates to `true` and is then implicitly cast to `1`, this is probably not what you wanted `O_WRONLY | O_NONBLOCK` is the proper combination and applies both attributes to the opened file.